### PR TITLE
Support Prettier v3

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -8,18 +8,18 @@ on:
   workflow_dispatch:
 
 jobs:
-  test:
+  env:
     runs-on: ${{ matrix.os }}
 
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        node-version: [14.x, 16.x]
+        node-version: [14, 16, latest]
 
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm ci
@@ -45,9 +45,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Use Node.js 16
-        uses: actions/setup-node@v1
-        with:
-          node-version: 16.x
+      - uses: actions/setup-node@v3
+        with: { node-version: 18 }
       - run: npm ci
       - run: npx prettier --check .

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -5,6 +5,8 @@ on:
     branches: [master]
   push:
     branches: [master]
+  schedule:
+    - cron: '0 12 * * 1' # At noon on Mondays
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -28,6 +28,21 @@ jobs:
   prettier:
     runs-on: ubuntu-latest
 
+    strategy:
+      matrix:
+        prettier-version: [2.3.0, latest, next]
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v3
+        with: { node-version: 18 }
+      - run: npm ci
+      - run: npm install prettier@${{ matrix.prettier-version }}
+      - run: NODE_OPTIONS=--experimental-vm-modules npm test
+
+  style:
+    runs-on: ubuntu-latest
+
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js 16

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Prettier for .properties Files
 
-Adds support to Prettier for [`.properties`](https://en.wikipedia.org/wiki/.properties) files. To use, just install it:
+Adds support to Prettier (v2.3 and later) for [`.properties`](https://en.wikipedia.org/wiki/.properties) files. To use, just install it:
 
 ```
 npm install --save-dev prettier-plugin-properties

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 const { parseLines, stringify } = require('dot-properties')
-const { concat, hardline } = require('prettier').doc.builders
+const { hardline } = require('prettier').doc.builders
 
 const { languages } = require('./languages')
 
@@ -22,14 +22,14 @@ const parser = {
 const printer = {
   print(path, options, print) {
     const node = path.getValue()
-    if (Array.isArray(node)) return concat(path.map(print))
+    if (Array.isArray(node)) return path.map(print)
     const opt = {
       indent: options.useTabs ? '\t' : ' '.repeat(options.tabWidth),
       keySep: options.keySeparator,
       latin1: options.escapeNonLatin1,
       lineWidth: options.printWidth
     }
-    return concat([stringify([node], opt), hardline])
+    return [stringify([node], opt), hardline]
   },
   hasPrettierIgnore(path) {
     const node = path.getValue()

--- a/index.test.js
+++ b/index.test.js
@@ -28,5 +28,5 @@ const cases = [
 for (const [src, exp, opt] of cases) {
   let name = src.replace(/\n/g, '\\n').replace(/\r/g, '\\r')
   if (opt) name += ` { ${Object.keys(opt)} }`
-  test(name, () => expect(format(src, opt)).toBe(exp))
+  test(name, async () => expect(await format(src, opt)).toBe(exp))
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,9 @@
         "jest": "^28.1.3",
         "linguist-languages": "^7.9.0",
         "prettier": "^2.0.4"
+      },
+      "peerDependencies": {
+        "prettier": ">= 2.3.0"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -41,5 +41,8 @@
     "jest": "^28.1.3",
     "linguist-languages": "^7.9.0",
     "prettier": "^2.0.4"
+  },
+  "peerDependencies": {
+    "prettier": ">= 2.3.0"
   }
 }


### PR DESCRIPTION
This drops the use of `require('prettier').doc.builders.concat()`, which makes Prettier v2.3 the minimum supported version.

CI tests are expanded to test on the whole supported range of Prettier versions, including a scheduled (weekly) test to track the upstream as it develops.