### PR TITLE
Fix removal of newlines after prettier-ignore

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,7 +22,18 @@ const parser = {
 const printer = {
   print(path, options, print) {
     const node = path.getValue()
-    if (Array.isArray(node)) return path.map(print)
+    if (Array.isArray(node)) {
+      const result = path.map(astPath => {
+        // This print method does not get called on the nodes that have a
+        // # prettier-ignore comment above them. So we need to return them
+        // with a hardline here.
+        if (this.hasPrettierIgnore(astPath)) {
+          return [print(astPath), hardline]
+        }
+        return print(astPath)
+      })
+      return result
+    }
     const opt = {
       indent: options.useTabs ? '\t' : ' '.repeat(options.tabWidth),
       keySep: options.keySeparator,

--- a/index.test.js
+++ b/index.test.js
@@ -29,7 +29,7 @@ const cases = [
     { keySeparator: '=', printWidth: 19 }
   ],
   [
-    'foo.bar=pizza hotdogs\n# prettier-ignore\nfoo.bar.sound=Lorem ipsum dolor\nfoo = bar',
+    'foo.bar=pizza hotdogs\n# prettier-ignore\nfoo.bar.sound=Lorem ipsum dolor\nfoo = bar ',
     'foo.bar=pizza \\\n  hotdogs\n# prettier-ignore\nfoo.bar.sound=Lorem ipsum dolor\nfoo=bar\n',
     { keySeparator: '=', printWidth: 19 }
   ],

--- a/index.test.js
+++ b/index.test.js
@@ -21,7 +21,22 @@ const cases = [
   ['# @format\nfoo=bar', '# @format\nfoo = bar\n', { insertPragma: true }],
   [
     'foo=foo\n# prettier-ignore\nbar:bar\n',
-    'foo = foo\n# prettier-ignore\nbar:bar'
+    'foo = foo\n# prettier-ignore\nbar:bar\n'
+  ],
+  [
+    '# prettier-ignore\nfoo.bar.sound=Lorem ipsum dolor\nfoo = bar',
+    '# prettier-ignore\nfoo.bar.sound=Lorem ipsum dolor\nfoo=bar\n',
+    { keySeparator: '=', printWidth: 19 }
+  ],
+  [
+    'foo.bar=pizza hotdogs\n# prettier-ignore\nfoo.bar.sound=Lorem ipsum dolor\nfoo = bar',
+    'foo.bar=pizza \\\n  hotdogs\n# prettier-ignore\nfoo.bar.sound=Lorem ipsum dolor\nfoo=bar\n',
+    { keySeparator: '=', printWidth: 19 }
+  ],
+  [
+    'foo.bar=pizza hotdogs\n# prettier-ignore\nfoo.bar.sound=hot\n# comment\nfoo = bar\n bar = bar\n',
+    'foo.bar=pizza \\\n  hotdogs\n# prettier-ignore\nfoo.bar.sound=hot\n# comment\nfoo=bar\nbar=bar\n',
+    { keySeparator: '=', printWidth: 19 }
   ]
 ]
 


### PR DESCRIPTION
Fixes issue https://github.com/eemeli/prettier-plugin-properties/issues/12

The trailing newline is no longer getting removed for the key-value pair after a `# prettier-ignore`.

For nodes where `hasPrettierIgnore` is true, the `printIgnored` method was being called rather than the `printer` defined by `prettier-plugin-properties`. Consequently, a hardline was not being added after the key-value pair node was printed.
https://github.com/prettier/prettier/blob/d0b907620b5a59fb75829e1b46e0636a064adae6/src/main/ast-to-doc.js#L101-L102 